### PR TITLE
fix: make sure we don't initialize mono before calling _start

### DIFF
--- a/samples/SampleHost/Program.cs
+++ b/samples/SampleHost/Program.cs
@@ -3,8 +3,8 @@ using Extism.Sdk.Native;
 
 using System.Text;
 
-// var path = "../SampleCSharpPlugin/bin/debug/net8.0/wasi-wasm/AppBundle/SampleCSharpPlugin.wasm";
-var path = "../SampleFSharpPlugin/bin/debug/net8.0/wasi-wasm/AppBundle/SampleFSharpPlugin.wasm";
+var path = "../SampleCSharpPlugin/bin/debug/net8.0/wasi-wasm/AppBundle/SampleCSharpPlugin.wasm";
+//var path = "../SampleFSharpPlugin/bin/debug/net8.0/wasi-wasm/AppBundle/SampleFSharpPlugin.wasm";
 
 Console.WriteLine(path);
 var bytes = File.ReadAllBytes(path);
@@ -14,11 +14,9 @@ var hf = new HostFunction("is_vowel", "host", new ExtismValType[] { ExtismValTyp
 
 void IsVowel(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outputs, nint userData)
 {
-    var bytes = plugin.ReadBytes(inputs[0].v.i32);
+    var c = (char)inputs[0].v.i32;
 
-    var text = Encoding.UTF8.GetString(bytes);
-
-    switch (char.ToLowerInvariant(text[0]))
+    switch (char.ToLowerInvariant(c))
     {
 
         case 'a':
@@ -38,15 +36,10 @@ void IsVowel(CurrentPlugin plugin, Span<ExtismVal> inputs, Span<ExtismVal> outpu
     outputs[0].v.i32 = 0;
 }
 
-var plugin = context.CreatePlugin(bytes, new HostFunction[] { }, withWasi: true);
+var plugin = context.CreatePlugin(bytes, new HostFunction[] { hf }, withWasi: true);
 
-// if (plugin.FunctionExists("_initialize"))
-// {
-//     plugin.CallFunction("_initialize", Span<byte>.Empty);
-// }
-
-var output = plugin.CallFunction("_start", Encoding.UTF8.GetBytes("Hello World!"));
+var output = plugin.CallFunction("count_vowels", Encoding.UTF8.GetBytes("Hello World!"));
 Console.WriteLine(Encoding.UTF8.GetString(output));
 
-output = plugin.CallFunction("_start", Encoding.UTF8.GetBytes("Hello World!"));
+output = plugin.CallFunction("count_vowels", Encoding.UTF8.GetBytes("Hello World!"));
 Console.WriteLine(Encoding.UTF8.GetString(output));

--- a/src/Extism.Pdk.MSBuild/FFIGenerator.cs
+++ b/src/Extism.Pdk.MSBuild/FFIGenerator.cs
@@ -97,8 +97,14 @@ namespace Extism.Pdk.MSBuild
                 WASI_AFTER_RUNTIME_LOADED_DECLARATIONS
                 #endif
 
-                __attribute__((export_name("_initialize"))) void initialize() {
+                bool mono_runtime_initialized = false;
+                void initialize_runtime() {
+                    if (mono_runtime_initialized) {
+                        return;
+                    }
+
                     mono_wasm_load_runtime("", 0);
+                    mono_runtime_initialized = true;
                 }
 
                 // end of _initialize
@@ -151,6 +157,8 @@ namespace Extism.Pdk.MSBuild
 MonoMethod* method_{{exportName}};
 __attribute__((export_name("{{exportName}}"))) int {{exportName}}()
 {
+    initialize_runtime();
+
     if (!method_{{exportName}})
     {
         method_{{exportName}} = lookup_dotnet_method("{{assemblyFileName}}", "{{method.DeclaringType.Namespace}}", "{{method.DeclaringType.Name}}", "{{method.Name}}", -1);

--- a/tests/Extism.Pdk.MsBuild.Tests/snapshots/exports.txt
+++ b/tests/Extism.Pdk.MsBuild.Tests/snapshots/exports.txt
@@ -24,8 +24,14 @@ void mono_wasm_load_runtime(const char* unused, int debug_level);
 WASI_AFTER_RUNTIME_LOADED_DECLARATIONS
 #endif
 
-__attribute__((export_name("_initialize"))) void initialize() {
+bool mono_runtime_initialized = false;
+void initialize_runtime() {
+    if (mono_runtime_initialized) {
+        return;
+    }
+
     mono_wasm_load_runtime("", 0);
+    mono_runtime_initialized = true;
 }
 
 // end of _initialize
@@ -62,6 +68,8 @@ void extism_print_exception(MonoObject* exc)
 MonoMethod* method_DoSomething;
 __attribute__((export_name("DoSomething"))) int DoSomething()
 {
+    initialize_runtime();
+
     if (!method_DoSomething)
     {
         method_DoSomething = lookup_dotnet_method("SampleApp.dll", "SampleNamespace", "SampleType", "DoSomething", -1);
@@ -92,6 +100,8 @@ __attribute__((export_name("DoSomething"))) int DoSomething()
 MonoMethod* method_fancy_name;
 __attribute__((export_name("fancy_name"))) int fancy_name()
 {
+    initialize_runtime();
+
     if (!method_fancy_name)
     {
         method_fancy_name = lookup_dotnet_method("SampleApp.dll", "SampleNamespace", "SampleType", "DoSomeOtherStuff", -1);


### PR DESCRIPTION
Currently, we are exporting an `_initialize` function that initializes the mono runtime. This is called by the host before calling the exported functions. However, the Rust SDK seems to call `_initialize` before `_start` too, which causes a problem because `_start` initializes the mono runtime too.

To fix this, I have changed the behavior of the PDK to NOT export `_initialize` anymore. Instead, we manually initialize the mono runtime before invoking any of the exported functions. This is inline with the behavior of some of the other compilers, namely: Rust ~~and Haskell~~.

This has another added benefit: wasmtime refused to call plugins that had both `_initialize` and `_start` functions exported. This is no longer an issue since we never export `_initialize` anymore