### PR TITLE
feat: import extism functions from `extism:host/env`

### DIFF
--- a/src/Extism.Pdk.MSBuild/FFIGenerator.cs
+++ b/src/Extism.Pdk.MSBuild/FFIGenerator.cs
@@ -7,12 +7,12 @@ namespace Extism.Pdk.MSBuild
     public class FFIGenerator
     {
         private readonly Action<string> _logError;
-        private readonly string _env;
+        private readonly string _extism;
 
-        public FFIGenerator(string env, Action<string> logError)
+        public FFIGenerator(string extism, Action<string> logError)
         {
             _logError = logError;
-            _env = env;
+            _extism = extism;
         }
 
         public IEnumerable<FileEntry> GenerateGlueCode(AssemblyDefinition assembly)
@@ -28,13 +28,13 @@ namespace Extism.Pdk.MSBuild
                 .Where(m => m.HasPInvokeInfo)
                 .ToArray();
 
-            var files = GenerateImports(importedMethods, _env);
+            var files = GenerateImports(importedMethods, _extism);
             files.Add(GenerateExports(assembly.Name.Name + ".dll", exportedMethods));
 
             return files;
         }
 
-        private List<FileEntry> GenerateImports(MethodDefinition[] importedMethods, string env)
+        private List<FileEntry> GenerateImports(MethodDefinition[] importedMethods, string extism)
         {
             var modules = importedMethods.GroupBy(m => m.PInvokeInfo.Module.Name)
                             .Select(g => new
@@ -44,7 +44,7 @@ namespace Extism.Pdk.MSBuild
                             })
                             .ToList();
 
-            var envWritten = false;
+            var extismWritten = false;
 
             var files = new List<FileEntry>();
 
@@ -54,10 +54,10 @@ namespace Extism.Pdk.MSBuild
             {
                 var builder = new StringBuilder();
 
-                if (module.Name == "env")
+                if (module.Name == "extism")
                 {
-                    envWritten = true;
-                    builder.AppendLine(env);
+                    extismWritten = true;
+                    builder.AppendLine(extism);
                 }
                 else
                 {
@@ -72,9 +72,9 @@ namespace Extism.Pdk.MSBuild
                 files.Add(new FileEntry { Name = $"{module.Name}.c", Content = builder.ToString() });
             }
 
-            if (!envWritten)
+            if (!extismWritten)
             {
-                files.Add(new FileEntry { Name = $"env.c", Content = env });
+                files.Add(new FileEntry { Name = $"extism.c", Content = extism });
             }
 
             return files;

--- a/src/Extism.Pdk.MSBuild/GenerateFFITask.cs
+++ b/src/Extism.Pdk.MSBuild/GenerateFFITask.cs
@@ -15,7 +15,7 @@ public class GenerateFFITask : Microsoft.Build.Utilities.Task
     public string OutputPath { get; set; }
 
     [Required]
-    public string EnvPath { get; set; }
+    public string ExtismPath { get; set; }
 
     public override bool Execute()
     {
@@ -36,7 +36,7 @@ public class GenerateFFITask : Microsoft.Build.Utilities.Task
                 }
             }
 
-            var generator = new FFIGenerator(File.ReadAllText(EnvPath), (string message) => Log.LogError(message));
+            var generator = new FFIGenerator(File.ReadAllText(ExtismPath), (string message) => Log.LogError(message));
 
             foreach (var file in generator.GenerateGlueCode(assembly))
             {

--- a/src/Extism.Pdk/Native.cs
+++ b/src/Extism.Pdk/Native.cs
@@ -12,74 +12,74 @@ internal static class Program
 internal class Native
 {
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern ulong extism_input_length();
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern ulong extism_length(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern ulong extism_alloc(ulong n);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_free(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern byte extism_input_load_u8(ulong index);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern ulong extism_input_load_u64(ulong index);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_output_set(ulong offset, ulong n);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_error_set(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern ulong extism_config_get(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern ulong extism_var_get(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_var_set(ulong keyOffset, ulong valueOffset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_store_u8(ulong offset, byte value);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern byte extism_load_u8(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_store_u64(ulong offset, ulong value);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern ulong extism_load_u64(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern ulong extism_http_request(ulong requestOffset, ulong bodyOffset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern ushort extism_http_status_code();
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_log_info(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_log_debug(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_log_warn(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_log_error(ulong offset);
 
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_store(ulong offset, byte* buffer, ulong n);
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_load(ulong offset, byte* buffer, ulong n);
-    [DllImport("env")]
+    [DllImport("extism")]
     internal static unsafe extern void extism_load_input(byte* buffer, ulong n);
     
     internal static void PrintException(Exception ex)

--- a/src/Extism.Pdk/build/Extism.Pdk.targets
+++ b/src/Extism.Pdk/build/Extism.Pdk.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<UsingTask TaskName="GenerateFFITask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\Extism.Pdk.MSBuild.dll" />
 	<Target Name="GenerateGlueCode" AfterTargets="Build" BeforeTargets="_BeforeWasmBuildApp">
-		<GenerateFFITask AssemblyPath="$(TargetPath)" OutputPath="$(IntermediateOutputPath)extism" EnvPath="$(MSBuildThisFileDirectory)..\native\env.c" />
+		<GenerateFFITask AssemblyPath="$(TargetPath)" OutputPath="$(IntermediateOutputPath)extism" ExtismPath="$(MSBuildThisFileDirectory)..\native\extism.c" />
 		<ItemGroup>
 			<NativeFileReference Include="$(IntermediateOutputPath)extism\*.c" />
 			<_WasmNativeFileForLinking Include="@(NativeFileReference)" />

--- a/src/Extism.Pdk/build/Extism.Pdk.targets
+++ b/src/Extism.Pdk/build/Extism.Pdk.targets
@@ -7,7 +7,7 @@
 			<_WasmNativeFileForLinking Include="@(NativeFileReference)" />
 
 			<!-- Wrap mono_runtime_run_main because we have to make sure at least one argument is passed in to Mono -->
-			<!-- See native/env.c for the implementation -->
+			<!-- See native/extism.c for the implementation -->
 			<_WasiSdkClangArgs Include="-Wl,--wrap=mono_runtime_run_main" />
 		</ItemGroup>
 	</Target>

--- a/src/Extism.Pdk/native/extism.c
+++ b/src/Extism.Pdk/native/extism.c
@@ -17,147 +17,147 @@
 
 typedef uint64_t ExtismPointer;
 
-IMPORT("extism::env", "input_length") 
+IMPORT("extism:env", "input_length") 
 extern uint64_t extism_input_length_import();
 
 uint64_t extism_input_length() {
     return extism_input_length_import();
 }
 
-IMPORT("extism::env", "length") 
+IMPORT("extism:env", "length") 
 extern uint64_t extism_length_import(ExtismPointer);
 
 uint64_t extism_length(ExtismPointer p) {
     return extism_length_import(p);
 }
 
-IMPORT("extism::env", "alloc")
+IMPORT("extism:env", "alloc")
 extern ExtismPointer extism_alloc_import(uint64_t size);
 
 ExtismPointer extism_alloc(uint64_t size) {
     return extism_alloc_import(size);
 }
 
-IMPORT("extism::env", "free") 
+IMPORT("extism:env", "free") 
 extern void extism_free_import(ExtismPointer p);
 
 void extism_free(ExtismPointer p) {
     extism_free_import(p);
 }
 
-IMPORT("extism::env", "input_load_u8") 
+IMPORT("extism:env", "input_load_u8") 
 extern uint8_t extism_input_load_u8_import(ExtismPointer p);
 
 uint8_t extism_input_load_u8(ExtismPointer p) {
     return extism_input_load_u8_import(p);
 }
 
-IMPORT("extism::env", "input_load_u64") 
+IMPORT("extism:env", "input_load_u64") 
 extern uint64_t extism_input_load_u64_import(ExtismPointer p);
 
 uint64_t extism_input_load_u64(ExtismPointer p) {
     return extism_input_load_u64_import(p);
 }
 
-IMPORT("extism::env", "output_set") 
+IMPORT("extism:env", "output_set") 
 extern void extism_output_set_import(ExtismPointer p, uint64_t value);
 
 void extism_output_set(ExtismPointer p, uint64_t value) {
     extism_output_set_import(p, value);
 }
 
-IMPORT("extism::env", "error_set") 
+IMPORT("extism:env", "error_set") 
 extern void extism_error_set_import(ExtismPointer p);
 
 void extism_error_set(ExtismPointer p) {
     extism_error_set_import(p);
 }
 
-IMPORT("extism::env", "config_get") 
+IMPORT("extism:env", "config_get") 
 extern ExtismPointer extism_config_get_import(ExtismPointer p);
 
 ExtismPointer extism_config_get(ExtismPointer p) {
     return extism_config_get_import(p);
 }
 
-IMPORT("extism::env", "var_get") 
+IMPORT("extism:env", "var_get") 
 extern ExtismPointer extism_var_get_import(ExtismPointer p);
 
 ExtismPointer extism_var_get(ExtismPointer p) {
     return extism_var_get_import(p);
 }
 
-IMPORT("extism::env", "var_set") 
+IMPORT("extism:env", "var_set") 
 extern void extism_var_set_import(ExtismPointer p1, ExtismPointer p2);
 
 void extism_var_set(ExtismPointer p1, ExtismPointer p2) {
     extism_var_set_import(p1, p2);
 }
 
-IMPORT("extism::env", "store_u8") 
+IMPORT("extism:env", "store_u8") 
 extern void extism_store_u8_import(ExtismPointer p, uint8_t value);
 
 void extism_store_u8(ExtismPointer p, uint8_t value) {
     extism_store_u8_import(p, value);
 }
 
-IMPORT("extism::env", "load_u8") 
+IMPORT("extism:env", "load_u8") 
 extern uint8_t extism_load_u8_import(ExtismPointer p);
 
 uint8_t extism_load_u8(ExtismPointer p) {
     return extism_load_u8_import(p);
 }
 
-IMPORT("extism::env", "store_u64") 
+IMPORT("extism:env", "store_u64") 
 extern void extism_store_u64_import(ExtismPointer p, uint64_t value);
 
 void extism_store_u64(ExtismPointer p, uint64_t value) {
     extism_store_u64_import(p, value);
 }
 
-IMPORT("extism::env", "load_u64") 
+IMPORT("extism:env", "load_u64") 
 extern uint64_t extism_load_u64_import(ExtismPointer p);
 
 uint64_t extism_load_u64(ExtismPointer p) {
     return extism_load_u64_import(p);
 }
 
-IMPORT("extism::env", "http_request") 
+IMPORT("extism:env", "http_request") 
 extern ExtismPointer extism_http_request_import(ExtismPointer p1, ExtismPointer p2);
 
 ExtismPointer extism_http_request(ExtismPointer p1, ExtismPointer p2) {
     return extism_http_request_import(p1, p2);
 }
 
-IMPORT("extism::env", "http_status_code") 
+IMPORT("extism:env", "http_status_code") 
 extern int32_t extism_http_status_code_import();
 
 int32_t extism_http_status_code() {
     return extism_http_status_code_import();
 }
 
-IMPORT("extism::env", "log_info") 
+IMPORT("extism:env", "log_info") 
 extern void extism_log_info_import(ExtismPointer p);
 
 void extism_log_info(ExtismPointer p) {
     extism_log_info_import(p);
 }
 
-IMPORT("extism::env", "log_debug") 
+IMPORT("extism:env", "log_debug") 
 extern void extism_log_debug_import(ExtismPointer p);
 
 void extism_log_debug(ExtismPointer p) {
     extism_log_debug_import(p);
 }
 
-IMPORT("extism::env", "log_warn") 
+IMPORT("extism:env", "log_warn") 
 extern void extism_log_warn_import(ExtismPointer p);
 
 void extism_log_warn(ExtismPointer p) {
     extism_log_warn_import(p);
 }
 
-IMPORT("extism::env", "log_error") 
+IMPORT("extism:env", "log_error") 
 extern void extism_log_error_import(ExtismPointer p);
 
 void extism_log_error(ExtismPointer p) {

--- a/src/Extism.Pdk/native/extism.c
+++ b/src/Extism.Pdk/native/extism.c
@@ -17,147 +17,147 @@
 
 typedef uint64_t ExtismPointer;
 
-IMPORT("extism", "extism_input_length") 
+IMPORT("extism::env", "input_length") 
 extern uint64_t extism_input_length_import();
 
 uint64_t extism_input_length() {
     return extism_input_length_import();
 }
 
-IMPORT("extism", "extism_length") 
+IMPORT("extism::env", "length") 
 extern uint64_t extism_length_import(ExtismPointer);
 
 uint64_t extism_length(ExtismPointer p) {
     return extism_length_import(p);
 }
 
-IMPORT("extism", "extism_alloc")
+IMPORT("extism::env", "alloc")
 extern ExtismPointer extism_alloc_import(uint64_t size);
 
 ExtismPointer extism_alloc(uint64_t size) {
     return extism_alloc_import(size);
 }
 
-IMPORT("extism", "extism_free") 
+IMPORT("extism::env", "free") 
 extern void extism_free_import(ExtismPointer p);
 
 void extism_free(ExtismPointer p) {
     extism_free_import(p);
 }
 
-IMPORT("extism", "extism_input_load_u8") 
+IMPORT("extism::env", "input_load_u8") 
 extern uint8_t extism_input_load_u8_import(ExtismPointer p);
 
 uint8_t extism_input_load_u8(ExtismPointer p) {
     return extism_input_load_u8_import(p);
 }
 
-IMPORT("extism", "extism_input_load_u64") 
+IMPORT("extism::env", "input_load_u64") 
 extern uint64_t extism_input_load_u64_import(ExtismPointer p);
 
 uint64_t extism_input_load_u64(ExtismPointer p) {
     return extism_input_load_u64_import(p);
 }
 
-IMPORT("extism", "extism_output_set") 
+IMPORT("extism::env", "output_set") 
 extern void extism_output_set_import(ExtismPointer p, uint64_t value);
 
 void extism_output_set(ExtismPointer p, uint64_t value) {
     extism_output_set_import(p, value);
 }
 
-IMPORT("extism", "extism_error_set") 
+IMPORT("extism::env", "error_set") 
 extern void extism_error_set_import(ExtismPointer p);
 
 void extism_error_set(ExtismPointer p) {
     extism_error_set_import(p);
 }
 
-IMPORT("extism", "extism_config_get") 
+IMPORT("extism::env", "config_get") 
 extern ExtismPointer extism_config_get_import(ExtismPointer p);
 
 ExtismPointer extism_config_get(ExtismPointer p) {
     return extism_config_get_import(p);
 }
 
-IMPORT("extism", "extism_var_get") 
+IMPORT("extism::env", "var_get") 
 extern ExtismPointer extism_var_get_import(ExtismPointer p);
 
 ExtismPointer extism_var_get(ExtismPointer p) {
     return extism_var_get_import(p);
 }
 
-IMPORT("extism", "extism_var_set") 
+IMPORT("extism::env", "var_set") 
 extern void extism_var_set_import(ExtismPointer p1, ExtismPointer p2);
 
 void extism_var_set(ExtismPointer p1, ExtismPointer p2) {
     extism_var_set_import(p1, p2);
 }
 
-IMPORT("extism", "extism_store_u8") 
+IMPORT("extism::env", "store_u8") 
 extern void extism_store_u8_import(ExtismPointer p, uint8_t value);
 
 void extism_store_u8(ExtismPointer p, uint8_t value) {
     extism_store_u8_import(p, value);
 }
 
-IMPORT("extism", "extism_load_u8") 
+IMPORT("extism::env", "load_u8") 
 extern uint8_t extism_load_u8_import(ExtismPointer p);
 
 uint8_t extism_load_u8(ExtismPointer p) {
     return extism_load_u8_import(p);
 }
 
-IMPORT("extism", "extism_store_u64") 
+IMPORT("extism::env", "store_u64") 
 extern void extism_store_u64_import(ExtismPointer p, uint64_t value);
 
 void extism_store_u64(ExtismPointer p, uint64_t value) {
     extism_store_u64_import(p, value);
 }
 
-IMPORT("extism", "extism_load_u64") 
+IMPORT("extism::env", "load_u64") 
 extern uint64_t extism_load_u64_import(ExtismPointer p);
 
 uint64_t extism_load_u64(ExtismPointer p) {
     return extism_load_u64_import(p);
 }
 
-IMPORT("extism", "extism_http_request") 
+IMPORT("extism::env", "http_request") 
 extern ExtismPointer extism_http_request_import(ExtismPointer p1, ExtismPointer p2);
 
 ExtismPointer extism_http_request(ExtismPointer p1, ExtismPointer p2) {
     return extism_http_request_import(p1, p2);
 }
 
-IMPORT("extism", "extism_http_status_code") 
+IMPORT("extism::env", "http_status_code") 
 extern int32_t extism_http_status_code_import();
 
 int32_t extism_http_status_code() {
     return extism_http_status_code_import();
 }
 
-IMPORT("extism", "extism_log_info") 
+IMPORT("extism::env", "log_info") 
 extern void extism_log_info_import(ExtismPointer p);
 
 void extism_log_info(ExtismPointer p) {
     extism_log_info_import(p);
 }
 
-IMPORT("extism", "extism_log_debug") 
+IMPORT("extism::env", "log_debug") 
 extern void extism_log_debug_import(ExtismPointer p);
 
 void extism_log_debug(ExtismPointer p) {
     extism_log_debug_import(p);
 }
 
-IMPORT("extism", "extism_log_warn") 
+IMPORT("extism::env", "log_warn") 
 extern void extism_log_warn_import(ExtismPointer p);
 
 void extism_log_warn(ExtismPointer p) {
     extism_log_warn_import(p);
 }
 
-IMPORT("extism", "extism_log_error") 
+IMPORT("extism::env", "log_error") 
 extern void extism_log_error_import(ExtismPointer p);
 
 void extism_log_error(ExtismPointer p) {

--- a/src/Extism.Pdk/native/extism.c
+++ b/src/Extism.Pdk/native/extism.c
@@ -17,147 +17,147 @@
 
 typedef uint64_t ExtismPointer;
 
-IMPORT("env", "extism_input_length") 
+IMPORT("extism", "extism_input_length") 
 extern uint64_t extism_input_length_import();
 
 uint64_t extism_input_length() {
     return extism_input_length_import();
 }
 
-IMPORT("env", "extism_length") 
+IMPORT("extism", "extism_length") 
 extern uint64_t extism_length_import(ExtismPointer);
 
 uint64_t extism_length(ExtismPointer p) {
     return extism_length_import(p);
 }
 
-IMPORT("env", "extism_alloc")
+IMPORT("extism", "extism_alloc")
 extern ExtismPointer extism_alloc_import(uint64_t size);
 
 ExtismPointer extism_alloc(uint64_t size) {
     return extism_alloc_import(size);
 }
 
-IMPORT("env", "extism_free") 
+IMPORT("extism", "extism_free") 
 extern void extism_free_import(ExtismPointer p);
 
 void extism_free(ExtismPointer p) {
     extism_free_import(p);
 }
 
-IMPORT("env", "extism_input_load_u8") 
+IMPORT("extism", "extism_input_load_u8") 
 extern uint8_t extism_input_load_u8_import(ExtismPointer p);
 
 uint8_t extism_input_load_u8(ExtismPointer p) {
     return extism_input_load_u8_import(p);
 }
 
-IMPORT("env", "extism_input_load_u64") 
+IMPORT("extism", "extism_input_load_u64") 
 extern uint64_t extism_input_load_u64_import(ExtismPointer p);
 
 uint64_t extism_input_load_u64(ExtismPointer p) {
     return extism_input_load_u64_import(p);
 }
 
-IMPORT("env", "extism_output_set") 
+IMPORT("extism", "extism_output_set") 
 extern void extism_output_set_import(ExtismPointer p, uint64_t value);
 
 void extism_output_set(ExtismPointer p, uint64_t value) {
     extism_output_set_import(p, value);
 }
 
-IMPORT("env", "extism_error_set") 
+IMPORT("extism", "extism_error_set") 
 extern void extism_error_set_import(ExtismPointer p);
 
 void extism_error_set(ExtismPointer p) {
     extism_error_set_import(p);
 }
 
-IMPORT("env", "extism_config_get") 
+IMPORT("extism", "extism_config_get") 
 extern ExtismPointer extism_config_get_import(ExtismPointer p);
 
 ExtismPointer extism_config_get(ExtismPointer p) {
     return extism_config_get_import(p);
 }
 
-IMPORT("env", "extism_var_get") 
+IMPORT("extism", "extism_var_get") 
 extern ExtismPointer extism_var_get_import(ExtismPointer p);
 
 ExtismPointer extism_var_get(ExtismPointer p) {
     return extism_var_get_import(p);
 }
 
-IMPORT("env", "extism_var_set") 
+IMPORT("extism", "extism_var_set") 
 extern void extism_var_set_import(ExtismPointer p1, ExtismPointer p2);
 
 void extism_var_set(ExtismPointer p1, ExtismPointer p2) {
     extism_var_set_import(p1, p2);
 }
 
-IMPORT("env", "extism_store_u8") 
+IMPORT("extism", "extism_store_u8") 
 extern void extism_store_u8_import(ExtismPointer p, uint8_t value);
 
 void extism_store_u8(ExtismPointer p, uint8_t value) {
     extism_store_u8_import(p, value);
 }
 
-IMPORT("env", "extism_load_u8") 
+IMPORT("extism", "extism_load_u8") 
 extern uint8_t extism_load_u8_import(ExtismPointer p);
 
 uint8_t extism_load_u8(ExtismPointer p) {
     return extism_load_u8_import(p);
 }
 
-IMPORT("env", "extism_store_u64") 
+IMPORT("extism", "extism_store_u64") 
 extern void extism_store_u64_import(ExtismPointer p, uint64_t value);
 
 void extism_store_u64(ExtismPointer p, uint64_t value) {
     extism_store_u64_import(p, value);
 }
 
-IMPORT("env", "extism_load_u64") 
+IMPORT("extism", "extism_load_u64") 
 extern uint64_t extism_load_u64_import(ExtismPointer p);
 
 uint64_t extism_load_u64(ExtismPointer p) {
     return extism_load_u64_import(p);
 }
 
-IMPORT("env", "extism_http_request") 
+IMPORT("extism", "extism_http_request") 
 extern ExtismPointer extism_http_request_import(ExtismPointer p1, ExtismPointer p2);
 
 ExtismPointer extism_http_request(ExtismPointer p1, ExtismPointer p2) {
     return extism_http_request_import(p1, p2);
 }
 
-IMPORT("env", "extism_http_status_code") 
+IMPORT("extism", "extism_http_status_code") 
 extern int32_t extism_http_status_code_import();
 
 int32_t extism_http_status_code() {
     return extism_http_status_code_import();
 }
 
-IMPORT("env", "extism_log_info") 
+IMPORT("extism", "extism_log_info") 
 extern void extism_log_info_import(ExtismPointer p);
 
 void extism_log_info(ExtismPointer p) {
     extism_log_info_import(p);
 }
 
-IMPORT("env", "extism_log_debug") 
+IMPORT("extism", "extism_log_debug") 
 extern void extism_log_debug_import(ExtismPointer p);
 
 void extism_log_debug(ExtismPointer p) {
     extism_log_debug_import(p);
 }
 
-IMPORT("env", "extism_log_warn") 
+IMPORT("extism", "extism_log_warn") 
 extern void extism_log_warn_import(ExtismPointer p);
 
 void extism_log_warn(ExtismPointer p) {
     extism_log_warn_import(p);
 }
 
-IMPORT("env", "extism_log_error") 
+IMPORT("extism", "extism_log_error") 
 extern void extism_log_error_import(ExtismPointer p);
 
 void extism_log_error(ExtismPointer p) {

--- a/tests/Extism.Pdk.MsBuild.Tests/ExtismFFIGeneratorTests.cs
+++ b/tests/Extism.Pdk.MsBuild.Tests/ExtismFFIGeneratorTests.cs
@@ -13,8 +13,8 @@ namespace Extism.Pdk.MsBuild.Tests
         [Fact]
         public void CanHandleEmptyAssemblies()
         {
-            var env = "";
-            var generator = new FFIGenerator(env, (m) => { });
+            var extism = "";
+            var generator = new FFIGenerator(extism, (m) => { });
 
             var assembly = CecilExtensions.CreateSampleAssembly("SampleApp");
 
@@ -22,25 +22,25 @@ namespace Extism.Pdk.MsBuild.Tests
         }
 
         [Fact]
-        public void CanImportFromEnv()
+        public void CanImportFromExtism()
         {
-            var env = "// env stuff";
-            var generator = new FFIGenerator(env, (m) => { });
+            var extism = "// extism stuff";
+            var generator = new FFIGenerator(extism, (m) => { });
 
             var assembly = CecilExtensions.CreateSampleAssembly("SampleApp");
 
             var type = assembly.MainModule.CreateType("MyNamespace", "MyClass");
 
             _ = type.CreateMethod("DoSomething", typeof(void), ("p1", typeof(int)), ("p2", typeof(byte)), ("p3", typeof(long)))
-                .AddImport("env", "do_something");
+                .AddImport("extism", "do_something");
 
             var files = generator.GenerateGlueCode(assembly);
 
-            var envFile = files.Single(f => f.Name == "env.c");
-            envFile.Content.Trim().ShouldBe(
+            var extismFile = files.Single(f => f.Name == "extism.c");
+            extismFile.Content.Trim().ShouldBe(
                 """
-                // env stuff
-                IMPORT("env", "do_something") extern void do_something_import(int32_t p1, uint8_t p2, int64_t p3);
+                // extism stuff
+                IMPORT("extism", "do_something") extern void do_something_import(int32_t p1, uint8_t p2, int64_t p3);
 
                 void do_something(int32_t p1, uint8_t p2, int64_t p3) {
                     do_something_import(p1, p2, p3);
@@ -53,40 +53,40 @@ namespace Extism.Pdk.MsBuild.Tests
         [Fact]
         public void CanImportFromCustomModules()
         {
-            var env = "// env stuff";
-            var generator = new FFIGenerator(env, (m) => { });
+            var extism = "// extism stuff";
+            var generator = new FFIGenerator(extism, (m) => { });
 
             var assembly = CecilExtensions.CreateSampleAssembly("SampleApp");
 
             var type = assembly.MainModule.CreateType("MyNamespace", "MyClass");
 
             _ = type.CreateMethod("DoSomething", typeof(void), ("p1", typeof(int)), ("p2", typeof(byte)), ("p3", typeof(long)))
-                .AddImport("host", "do_something");
+                .AddImport("env", "do_something");
 
             _ = type.CreateMethod("GetLength", typeof(int), ("p1", typeof(float)))
-                .AddImport("host", null);
+                .AddImport("env", null);
 
             var files = generator.GenerateGlueCode(assembly);
 
-            var hostFile = files.Single(f => f.Name == "host.c");
+            var envFile = files.Single(f => f.Name == "env.c");
             var expected = File.ReadAllText("snapshots/import-custom-module.txt");
-            hostFile.Content.Trim().ShouldBe(expected, StringCompareShould.IgnoreLineEndings);
+            envFile.Content.Trim().ShouldBe(expected, StringCompareShould.IgnoreLineEndings);
 
-            AssertContent(env, files, "env.c");
+            AssertContent(extism, files, "extism.c");
             files.ShouldNotContain(f => f.Name == "export.c");
         }
 
         private static void AssertContent(string content, IEnumerable<FileEntry> files, string fileName)
         {
-            var envFile = files.Single(f => f.Name == fileName);
-            envFile.Content.Trim().ShouldBe(content.Trim(), StringCompareShould.IgnoreLineEndings);
+            var extismFile = files.Single(f => f.Name == fileName);
+            extismFile.Content.Trim().ShouldBe(content.Trim(), StringCompareShould.IgnoreLineEndings);
         }
 
         [Fact]
         public void CanExportMethods()
         {
-            var env = "// env stuff";
-            var generator = new FFIGenerator(env, (m) => { });
+            var extism = "// extism stuff";
+            var generator = new FFIGenerator(extism, (m) => { });
 
             var assembly = CecilExtensions.CreateSampleAssembly("SampleApp");
 
@@ -104,7 +104,7 @@ namespace Extism.Pdk.MsBuild.Tests
             var expected = File.ReadAllText("snapshots/exports.txt");
             file.Content.Trim().ShouldBe(expected, StringCompareShould.IgnoreLineEndings);
 
-            AssertContent(env, files, "env.c");
+            AssertContent(extism, files, "extism.c");
         }
     }
 

--- a/tests/Extism.Pdk.MsBuild.Tests/snapshots/import-custom-module.txt
+++ b/tests/Extism.Pdk.MsBuild.Tests/snapshots/import-custom-module.txt
@@ -16,12 +16,12 @@
 #define IMPORT(a, b) __attribute__((import_module(a), import_name(b)))
 
 typedef uint64_t ExtismPointer;
-IMPORT("host", "do_something") extern void do_something_import(int32_t p1, uint8_t p2, int64_t p3);
+IMPORT("env", "do_something") extern void do_something_import(int32_t p1, uint8_t p2, int64_t p3);
 
 void do_something(int32_t p1, uint8_t p2, int64_t p3) {
     do_something_import(p1, p2, p3);
 }
-IMPORT("host", "GetLength") extern int32_t GetLength_import(float p1);
+IMPORT("env", "GetLength") extern int32_t GetLength_import(float p1);
 
 int32_t GetLength(float p1) {
     return GetLength_import(p1);

--- a/tests/Extism.Pdk.WasmTests/KitchenSinkTests.cs
+++ b/tests/Extism.Pdk.WasmTests/KitchenSinkTests.cs
@@ -48,8 +48,7 @@ public class KitchenSinkTests
 
         stderr.ShouldBe("");
         exit.ShouldBe(0);
-        // TODO: Enable this again after the Extism CLI is fixed
-        //stdout.ShouldBe("1\n2\n3\n");
+        stdout.ShouldBe("1\n2\n3\n");
     }
 
     [Theory]
@@ -141,19 +140,17 @@ public class KitchenSinkTests
         public int Loop { get; set; }
         public string Input { get; set; } = "";
         public bool Wasi { get; set; } = true;
-        public bool Quiet { get; set; }
         public Dictionary<string, string> Config { get; set; } = new();
         public List<string> AllowedHosts { get; set; } = new List<string>();
 
         public string[] ToCliArguments()
         {
             var wasiArg = Wasi ? "--wasi" : "";
-            var quietArg = Quiet ? "-q" : "";
 
             var configs = Config.Where(c => !string.IsNullOrEmpty(c.Value)).SelectMany(c => new string[] { "--config", $"{c.Key}={c.Value}" });
             var hosts = AllowedHosts.Where(h => !string.IsNullOrEmpty(h)).SelectMany(h => new string[] { "--allow-host", h });
 
-            return ["--loop", Loop.ToString(), "--input", Input, quietArg, wasiArg, .. configs, .. hosts];
+            return ["--loop", Loop.ToString(), "--input", Input, wasiArg, .. configs, .. hosts];
         }
     }
 }


### PR DESCRIPTION
This part of the extism/extism/issues/504 effort to move extism functions to `extism::env`. I have tested this with a modified go-sdk