### PR TITLE
fix: update nuget command to download prerelease version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create a new project and add this nuget package to your project:
 ```
 dotnet new wasiconsole -o MyPlugin
 cd MyPlugin
-dotnet add package Extism.Pdk 
+dotnet add package Extism.Pdk --prerelease
 ```
 
 Update your MyPlugin.csproj as follows:


### PR DESCRIPTION
The PDK is currently in prerelease state, so we have to specify the `--prerelease` flag