### PR TITLE
fix: allow users to import user host functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Host functions have a similar interface as exports. You just need to declare the
 
 C#:
 ```csharp
-[DllImport("env", EntryPoint = "a_go_func")]
+[DllImport("extism", EntryPoint = "a_go_func")]
 public static extern ulong GoFunc(ulong offset);
 [UnmanagedCallersOnly]
 public static int hello_from_go()
@@ -383,7 +383,7 @@ public static int hello_from_go()
 
 F#:
 ```fsharp
-[<DllImport("env", EntryPoint = "a_go_func")>]
+[<DllImport("extism", EntryPoint = "a_go_func")>]
 extern uint64 GoFunc(uint64 offset)
 
 [<UnmanagedCallersOnly>]
@@ -411,7 +411,7 @@ config := extism.PluginConfig{
 
 go_func := extism.NewHostFunctionWithStack(
     "a_go_func",
-    "env",
+    "extism:host/user",
     func(ctx context.Context, p *extism.CurrentPlugin, stack []uint64) {
         input, err := p.ReadString(stack[0])
         if err != nil {

--- a/samples/SampleCSharpPlugin/Functions.cs
+++ b/samples/SampleCSharpPlugin/Functions.cs
@@ -5,7 +5,7 @@ namespace SampleCSharpPlugin
 {
     public static class Functions
     {
-        [DllImport("host", EntryPoint = "is_vowel")]
+        [DllImport("extism", EntryPoint = "is_vowel")]
         public static extern int IsVowel(int c);
 
         [UnmanagedCallersOnly(EntryPoint = "count_vowels")]

--- a/src/Extism.Pdk.MSBuild/FFIGenerator.cs
+++ b/src/Extism.Pdk.MSBuild/FFIGenerator.cs
@@ -191,6 +191,14 @@ __attribute__((export_name("{{exportName}}"))) int {{exportName}}()
         private string ToImportStatement(MethodDefinition method)
         {
             var moduleName = method.PInvokeInfo.Module.Name;
+            if (moduleName == "extism")
+            {
+                // Redirect imported host functions to extism:host/user
+                // The PDK functions don't use this generator, so we can safely assume
+                // every `extism` import is a user host function
+                moduleName = "extism:host/user";
+            }
+
             var functionName = method.PInvokeInfo.EntryPoint ?? method.Name;
 
             if (!_types.ContainsKey(method.ReturnType.Name))

--- a/tests/Extism.Pdk.MsBuild.Tests/ExtismFFIGeneratorTests.cs
+++ b/tests/Extism.Pdk.MsBuild.Tests/ExtismFFIGeneratorTests.cs
@@ -40,7 +40,7 @@ namespace Extism.Pdk.MsBuild.Tests
             extismFile.Content.Trim().ShouldBe(
                 """
                 // extism stuff
-                IMPORT("extism", "do_something") extern void do_something_import(int32_t p1, uint8_t p2, int64_t p3);
+                IMPORT("extism:host/user", "do_something") extern void do_something_import(int32_t p1, uint8_t p2, int64_t p3);
 
                 void do_something(int32_t p1, uint8_t p2, int64_t p3) {
                     do_something_import(p1, p2, p3);

--- a/tests/Extism.Pdk.WasmTests/KitchenSinkTests.cs
+++ b/tests/Extism.Pdk.WasmTests/KitchenSinkTests.cs
@@ -114,8 +114,6 @@ public class KitchenSinkTests
         exit.ShouldBe(1);
     }
 
-    // TODO: test function imports
-
     private string GetWasmPath(string name)
     {
         return Path.Combine(


### PR DESCRIPTION
Currently, the .NET toolchain has issues with namespaces that contain `:` and `/`. For more details please see dotnet/runtime/issues/94513. As a workaround, if the user imports from `extism`, we assume they mean `extism:host/user`.