### PR TITLE
fix: only run Extism.Pdk.MSBuild on projects whose runtime identifier is wasi-wasm

### DIFF
--- a/src/Extism.Pdk/build/Extism.Pdk.targets
+++ b/src/Extism.Pdk/build/Extism.Pdk.targets
@@ -3,7 +3,7 @@
 		<TrimmerRootAssembly Include="Extism.Pdk" />
 	</ItemGroup>
 
-	<UsingTask TaskName="GenerateFFITask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\Extism.Pdk.MSBuild.dll" />
+	<UsingTask TaskName="GenerateFFITask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\Extism.Pdk.MSBuild.dll" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm'"/>
 	<Target Name="GenerateGlueCode" AfterTargets="Build" BeforeTargets="_BeforeWasmBuildApp">
 		<GenerateFFITask AssemblyPath="$(TargetPath)" OutputPath="$(IntermediateOutputPath)extism" ExtismPath="$(MSBuildThisFileDirectory)..\native\extism.c" />
 		<ItemGroup>


### PR DESCRIPTION
Since class libraries are just intermediate dependencies and don't produce wasm files, we shouldn't generate any glue code when building them, the glue code will be generated when an app is built that is referencing them

Fixes #34 