### PR TITLE
fix: fail the build with a descriptive error message when the users tries to export functions with parameters

### DIFF
--- a/src/Extism.Pdk.MSBuild/FFIGenerator.cs
+++ b/src/Extism.Pdk.MSBuild/FFIGenerator.cs
@@ -149,6 +149,12 @@ namespace Extism.Pdk.MSBuild
 
                 foreach (var method in exportedMethods)
                 {
+                    if (method.Parameters.Count > 0)
+                    {
+                        var parameterNames = string.Join(",", method.Parameters.Select(p => $"{p.ParameterType.Name} {p.Name}"));
+                        _logError($"Extism doesn't support exporting functions that have parameters: {method.DeclaringType.FullName}.{method.Name}({parameterNames})");
+                    }
+
                     var assemblyFileName = method.Module.Assembly.Name.Name + ".dll";
                     var attribute = method.CustomAttributes.First(a => a.AttributeType.Name == "UnmanagedCallersOnlyAttribute");
 


### PR DESCRIPTION
Fixes #36

For this function:
```csharp
namespace SampleCSharpPlugin;
public static class Functions
{
    [UnmanagedCallersOnly(EntryPoint = "count_vowels")]
    public static int CountVowels(int nnn)
    {
    
    }
}
```

We will get this error:
```
Extism doesn't support exporting functions that have parameters: SampleCSharpPlugin.Functions.CountVowels(Int32 nnn)
```