### PR TITLE
fix: Don't run GenerateGlueCode task for referenced libraries don't don't target wasi-wasm

### DIFF
--- a/src/Extism.Pdk/build/Extism.Pdk.targets
+++ b/src/Extism.Pdk/build/Extism.Pdk.targets
@@ -4,7 +4,7 @@
 	</ItemGroup>
 
 	<UsingTask TaskName="GenerateFFITask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\Extism.Pdk.MSBuild.dll" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm'"/>
-	<Target Name="GenerateGlueCode" AfterTargets="Build" BeforeTargets="_BeforeWasmBuildApp">
+	<Target Name="GenerateGlueCode" AfterTargets="Build" BeforeTargets="_BeforeWasmBuildApp" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm'">
 		<GenerateFFITask AssemblyPath="$(TargetPath)" OutputPath="$(IntermediateOutputPath)extism" ExtismPath="$(MSBuildThisFileDirectory)..\native\extism.c" />
 		<ItemGroup>
 			<NativeFileReference Include="$(IntermediateOutputPath)extism\*.c" />


### PR DESCRIPTION
Seems like #35 caused a regression because it didn't completely disable the task, this PR finishes the job