### PR TITLE
fix: remove condition on .targets property group

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,6 @@ Update your `MyPlugin.csproj`/`MyPlugin.fsproj` as follows:
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
-    <PublishTrimmed>true</PublishTrimmed>
-
-    <!-- Make sure we create a standalone wasm file for our plugin -->
-    <WasmSingleFileBundle>true</WasmSingleFileBundle>
-    <WasmBuildNative>true</WasmBuildNative>
   </PropertyGroup>
 </Project>
 ```

--- a/src/Extism.Pdk/build/Extism.Pdk.targets
+++ b/src/Extism.Pdk/build/Extism.Pdk.targets
@@ -3,7 +3,7 @@
 		<TrimmerRootAssembly Include="Extism.Pdk" />
 	</ItemGroup>
 
-	<PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+	<PropertyGroup>
 		<PublishTrimmed>true</PublishTrimmed>
 		<WasmBuildNative>true</WasmBuildNative>
 		<WasmSingleFileBundle>true</WasmSingleFileBundle>


### PR DESCRIPTION
We want dotnet to build a single file even in debug mode, and the other properties only apply when running dotnet publish anyway