### PR TITLE
ci: use token to install libextism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Extism CLI
         run: |
           go install github.com/extism/cli/extism@latest
-          extism lib install --prefix ~/extism --version git
+          extism lib install --prefix ~/extism --version git --github-token ${{ github.token }}
           mkdir -p ./tests/Extism.Pdk.WasmTests/bin/Debug/net8.0
           cp ~/extism/lib/libextism.so ./tests/Extism.Pdk.WasmTests/bin/Debug/net8.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Extism CLI
         run: |
           go install github.com/extism/cli/extism@latest
-          extism lib install --prefix ~/extism --version git
+          extism lib install --prefix ~/extism --version git --github-token ${{ github.token }}
           mkdir -p ./tests/Extism.Pdk.WasmTests/bin/Debug/net8.0
           cp ~/extism/lib/libextism.so ./tests/Extism.Pdk.WasmTests/bin/Debug/net8.0
 


### PR DESCRIPTION
This one is a little different as it doesn't use the separate install libextism action.