### PR TITLE
fix: Pin to .NET 8

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.404",
+    "rollForward": "latestFeature"
+  }
+}

--- a/samples/SampleHost/SampleHost.csproj
+++ b/samples/SampleHost/SampleHost.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Extism.Pdk/Extism.Pdk.csproj
+++ b/src/Extism.Pdk/Extism.Pdk.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
+		<SupportedVersions>net8.0</SupportedVersions>
 		<RootNamespace>Extism.Pdk</RootNamespace>
 		<RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
 		<OutputType>Library</OutputType>

--- a/src/Extism.Pdk/Extism.Pdk.csproj
+++ b/src/Extism.Pdk/Extism.Pdk.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<SupportedVersions>net8.0</SupportedVersions>
 		<RootNamespace>Extism.Pdk</RootNamespace>
 		<RuntimeIdentifier>wasi-wasm</RuntimeIdentifier>
 		<OutputType>Library</OutputType>

--- a/src/Extism.Pdk/build/Extism.Pdk.targets
+++ b/src/Extism.Pdk/build/Extism.Pdk.targets
@@ -14,7 +14,12 @@
 		<EventSourceSupport>false</EventSourceSupport>
 		<UseSystemResourceKeys>true</UseSystemResourceKeys>
 		<NativeDebugSymbols>false</NativeDebugSymbols>
+		<UseAppHost>false</UseAppHost>
 	</PropertyGroup>
+
+	<Target Name="EnforceDotNet8" BeforeTargets="Build">
+		<Error Condition="'$(TargetFramework)' != 'net8.0'" Text="Extism PDK can only be used in projects targeting .NET 8. See https://github.com/extism/dotnet-pdk/issues/110" />
+	</Target>
 
 	<UsingTask TaskName="GenerateFFITask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\Extism.Pdk.MSBuild.dll" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm'"/>
 	<Target Name="GenerateGlueCode" AfterTargets="Build" BeforeTargets="_BeforeWasmBuildApp" Condition="'$(RuntimeIdentifier)' == 'wasi-wasm'">


### PR DESCRIPTION
This make sure the build fails when targeting any other version beside .NET 8

Fixes #110 